### PR TITLE
Split ConfigOption read into two steps: parse() and convert()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.baidu.hugegraph</groupId>
     <artifactId>hugegraph-common</artifactId>
-    <version>1.6.16</version>
+    <version>1.7.0</version>
 
     <name>hugegraph-common</name>
     <url>https://github.com/hugegraph/hugegraph-common</url>
@@ -218,7 +218,7 @@
                         <manifestEntries>
                             <!-- Must be on one line, otherwise the automatic
                                  upgrade script cannot replace the version number -->
-                            <Implementation-Version>1.6.16.0</Implementation-Version>
+                            <Implementation-Version>1.7.0.0</Implementation-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/src/main/java/com/baidu/hugegraph/config/ConfigConvOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/ConfigConvOption.java
@@ -21,27 +21,29 @@ package com.baidu.hugegraph.config;
 
 import java.util.function.Function;
 
+import com.baidu.hugegraph.util.E;
 import com.google.common.base.Predicate;
 
-public class ConfigConvOption<R> extends TypedOption<String, R> {
+public class ConfigConvOption<T, R> extends TypedOption<T, R> {
 
-    private final Function<String, R> converter;
+    private final Function<T, R> converter;
 
-    public ConfigConvOption(String name, String desc, Predicate<String> pred,
-                            Function<String, R> convert, String value) {
+    public ConfigConvOption(String name, String desc, Predicate<T> pred,
+                            Function<T, R> convert, T value) {
         this(name, false, desc, pred, convert, value);
     }
 
+    @SuppressWarnings("unchecked")
     public ConfigConvOption(String name, boolean required, String desc,
-                            Predicate<String> pred, Function<String, R> convert,
-                            String value) {
-        super(name, required, desc, pred, String.class, value);
+                            Predicate<T> pred, Function<T, R> convert,
+                            T value) {
+        super(name, required, desc, pred, (Class<T>) value.getClass(), value);
+        E.checkNotNull(convert, "convert");
         this.converter = convert;
     }
 
     @Override
-    public R convert(Object value) {
-        assert value instanceof String;
-        return this.converter.apply((String) value);
+    public R convert(T value) {
+        return this.converter.apply(value);
     }
 }

--- a/src/main/java/com/baidu/hugegraph/config/ConfigListConvOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/ConfigListConvOption.java
@@ -36,8 +36,7 @@ public class ConfigListConvOption<T, R> extends TypedOption<List<T>, List<R>> {
     public ConfigListConvOption(String name, String desc,
                                 Predicate<List<T>> pred, Function<T, R> convert,
                                 T... values) {
-        this(name, false, desc, pred, convert,
-             (Class<T>) values[0].getClass(), Arrays.asList(values));
+        this(name, false, desc, pred, convert, null, Arrays.asList(values));
     }
 
     @SuppressWarnings("unchecked")
@@ -46,8 +45,11 @@ public class ConfigListConvOption<T, R> extends TypedOption<List<T>, List<R>> {
                                 Class<T> clazz, List<T> values) {
         super(name, required, desc, pred,
               (Class<List<T>>) values.getClass(), values);
-        E.checkNotNull(clazz, "element class");
         E.checkNotNull(convert, "convert");
+        if (clazz == null && values.size() > 0) {
+            clazz = (Class<T>) values.get(0).getClass();
+        }
+        E.checkArgumentNotNull(clazz, "Element class can't be null");
         this.elemClass = clazz;
         this.converter = convert;
     }

--- a/src/main/java/com/baidu/hugegraph/config/ConfigListConvOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/ConfigListConvOption.java
@@ -35,15 +35,9 @@ public class ConfigListConvOption<T, R> extends TypedOption<List<T>, List<R>> {
     @SuppressWarnings("unchecked")
     public ConfigListConvOption(String name, String desc,
                                 Predicate<List<T>> pred, Function<T, R> convert,
-                                T value) {
-        this(name, desc, pred, convert, (Class<T>) value.getClass(), value);
-    }
-
-    @SuppressWarnings("unchecked")
-    public ConfigListConvOption(String name, String desc,
-                                Predicate<List<T>> pred, Function<T, R> convert,
-                                Class<T> clazz, T... values) {
-        this(name, false, desc, pred, convert, clazz, Arrays.asList(values));
+                                T... values) {
+        this(name, false, desc, pred, convert,
+             (Class<T>) values[0].getClass(), Arrays.asList(values));
     }
 
     @SuppressWarnings("unchecked")
@@ -52,21 +46,30 @@ public class ConfigListConvOption<T, R> extends TypedOption<List<T>, List<R>> {
                                 Class<T> clazz, List<T> values) {
         super(name, required, desc, pred,
               (Class<List<T>>) values.getClass(), values);
-        E.checkArgumentNotNull(clazz, "Element class can't be null");
+        E.checkNotNull(clazz, "element class");
+        E.checkNotNull(convert, "convert");
         this.elemClass = clazz;
         this.converter = convert;
     }
 
     @Override
-    public List<R> convert(Object value) {
-        List<T> results = ConfigListOption.convert(value, part -> {
-            return super.convert(part, this.elemClass);
-        });
+    protected boolean forList() {
+        return true;
+    }
 
-        List<R> enums = new ArrayList<>(results.size());
-        for (T elem : results) {
-            enums.add(this.converter.apply(elem));
+    @Override
+    protected List<T> parse(Object value) {
+        return ConfigListOption.convert(value, part -> {
+            return this.parse(part, this.elemClass);
+        });
+    }
+
+    @Override
+    public List<R> convert(List<T> values) {
+        List<R> results = new ArrayList<>(values.size());
+        for (T value : values) {
+            results.add(this.converter.apply(value));
         }
-        return enums;
+        return results;
     }
 }

--- a/src/main/java/com/baidu/hugegraph/config/ConfigListOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/ConfigListOption.java
@@ -33,15 +33,9 @@ public class ConfigListOption<T> extends ConfigOption<List<T>> {
 
     @SuppressWarnings("unchecked")
     public ConfigListOption(String name, String desc,
-                            Predicate<List<T>> pred, T value) {
-        this(name, desc, pred, (Class<T>) value.getClass(), value);
-    }
-
-    @SuppressWarnings("unchecked")
-    public ConfigListOption(String name, String desc,
-                            Predicate<List<T>> pred, Class<T> clazz,
-                            T... values) {
-        this(name, false, desc, pred, clazz, Arrays.asList(values));
+                            Predicate<List<T>> pred, T... values) {
+        this(name, false, desc, pred,
+             (Class<T>) values[0].getClass(), Arrays.asList(values));
     }
 
     @SuppressWarnings("unchecked")
@@ -55,8 +49,13 @@ public class ConfigListOption<T> extends ConfigOption<List<T>> {
     }
 
     @Override
-    public List<T> convert(Object value) {
-        return convert(value, part -> super.convert(part, this.elemClass));
+    protected boolean forList() {
+        return true;
+    }
+
+    @Override
+    protected List<T> parse(Object value) {
+        return convert(value, part -> this.parse(part, this.elemClass));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/baidu/hugegraph/config/ConfigListOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/ConfigListOption.java
@@ -34,8 +34,7 @@ public class ConfigListOption<T> extends ConfigOption<List<T>> {
     @SuppressWarnings("unchecked")
     public ConfigListOption(String name, String desc,
                             Predicate<List<T>> pred, T... values) {
-        this(name, false, desc, pred,
-             (Class<T>) values[0].getClass(), Arrays.asList(values));
+        this(name, false, desc, pred, null, Arrays.asList(values));
     }
 
     @SuppressWarnings("unchecked")
@@ -44,6 +43,9 @@ public class ConfigListOption<T> extends ConfigOption<List<T>> {
                             List<T> values) {
         super(name, required, desc, pred,
               (Class<List<T>>) values.getClass(), values);
+        if (clazz == null && values.size() > 0) {
+            clazz = (Class<T>) values.get(0).getClass();
+        }
         E.checkArgumentNotNull(clazz, "Element class can't be null");
         this.elemClass = clazz;
     }

--- a/src/main/java/com/baidu/hugegraph/config/HugeConfig.java
+++ b/src/main/java/com/baidu/hugegraph/config/HugeConfig.java
@@ -145,17 +145,7 @@ public class HugeConfig extends PropertiesConfiguration {
                         "Invalid value for key '%s': %s", key, value);
 
         TypedOption<?, ?> option = OptionSpace.get(key);
-        Class<?> dataType = option.dataType();
-
-        if (List.class.isAssignableFrom(dataType)) {
-            E.checkState(option instanceof ConfigListOption,
-                         "List option must be registered with " +
-                         "class ConfigListOption");
-        }
-
-        value = option.convert(value);
-        option.check(value);
-        return value;
+        return option.parseConvert(value);
     }
 
     private void checkRequiredOptions() {

--- a/src/main/java/com/baidu/hugegraph/config/HugeConfig.java
+++ b/src/main/java/com/baidu/hugegraph/config/HugeConfig.java
@@ -48,9 +48,6 @@ public class HugeConfig extends PropertiesConfiguration {
         Iterator<String> keys = config.getKeys();
         while (keys.hasNext()) {
             String key = keys.next();
-            if (key.contains("..")) {
-                key = key.replace("..", ".");
-            }
             this.addProperty(key, config.getProperty(key));
         }
         this.checkRequiredOptions();

--- a/src/main/java/com/baidu/hugegraph/config/OptionHolder.java
+++ b/src/main/java/com/baidu/hugegraph/config/OptionHolder.java
@@ -40,6 +40,10 @@ public class OptionHolder {
 
     protected void registerOptions() {
         for (Field field : this.getClass().getFields()) {
+            if (!TypedOption.class.isAssignableFrom(field.getType())) {
+                // Skip if not option
+                continue;
+            }
             try {
                 TypedOption<?, ?> option = (TypedOption<?, ?>) field.get(this);
                 // Fields of subclass first, don't overwrite by superclass

--- a/src/main/java/com/baidu/hugegraph/config/OptionSpace.java
+++ b/src/main/java/com/baidu/hugegraph/config/OptionSpace.java
@@ -21,12 +21,14 @@ package com.baidu.hugegraph.config;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 
+import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
 
 public final class OptionSpace {
@@ -63,6 +65,11 @@ public final class OptionSpace {
         try {
             Method method = clazz.getMethod(INSTANCE_METHOD);
             instance = (OptionHolder) method.invoke(null);
+            if (instance == null) {
+                exception = new ConfigException(
+                                "Returned null from %s() method",
+                                INSTANCE_METHOD);
+            }
         } catch (NoSuchMethodException e) {
             LOG.warn("Class {} does not has static method {}.",
                      holder, INSTANCE_METHOD);
@@ -91,6 +98,7 @@ public final class OptionSpace {
             LOG.warn("Already registered option holder: {} ({})",
                      module, holders.get(module));
         }
+        E.checkArgumentNotNull(holder, "OptionHolder can't be null");
         holders.put(module, holder.getClass());
         options.putAll(holder.options());
         LOG.debug("Registered options for OptionHolder: {}",
@@ -98,10 +106,10 @@ public final class OptionSpace {
     }
 
     public static Set<String> keys() {
-        return options.keySet();
+        return Collections.unmodifiableSet(options.keySet());
     }
 
-    public static Boolean containKey(String key) {
+    public static boolean containKey(String key) {
         return options.containsKey(key);
     }
 

--- a/src/main/java/com/baidu/hugegraph/config/OptionSpace.java
+++ b/src/main/java/com/baidu/hugegraph/config/OptionSpace.java
@@ -21,6 +21,7 @@ package com.baidu.hugegraph.config;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -64,6 +65,9 @@ public final class OptionSpace {
         Exception exception = null;
         try {
             Method method = clazz.getMethod(INSTANCE_METHOD);
+            if (!Modifier.isStatic(method.getModifiers())) {
+                throw new NoSuchMethodException(INSTANCE_METHOD);
+            }
             instance = (OptionHolder) method.invoke(null);
             if (instance == null) {
                 exception = new ConfigException(

--- a/src/main/java/com/baidu/hugegraph/config/TypedOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/TypedOption.java
@@ -112,14 +112,24 @@ public class TypedOption<T, R> {
         return this.convert(this.defaultValue);
     }
 
-    @SuppressWarnings("unchecked")
-    public R convert(Object value) {
-        return (R) this.convert(value, this.dataType);
+    public R parseConvert(Object value) {
+        T parsed = this.parse(value);
+        this.check(parsed);
+        return this.convert(parsed);
     }
 
-    public Object convert(Object value, Class<?> dataType) {
+    @SuppressWarnings("unchecked")
+    protected T parse(Object value) {
+        return (T) this.parse(value, this.dataType);
+    }
+
+    protected Object parse(Object value, Class<?> dataType) {
         if (dataType.equals(String.class)) {
             return value;
+        } else if (List.class.isAssignableFrom(dataType)) {
+            E.checkState(this.forList(),
+                         "List option can't be registered with class %s",
+                         this.getClass().getSimpleName());
         }
 
         // Use PropertyConverter method `toXXX` convert value
@@ -138,11 +148,13 @@ public class TypedOption<T, R> {
         }
     }
 
-    public void check(Object value) {
+    protected void check(Object value) {
         E.checkNotNull(value, "value", this.name);
         E.checkArgument(this.dataType.isInstance(value),
-                        "Invalid type of value '%s' for option '%s'",
-                        value, this.name);
+                        "Invalid type of value '%s' for option '%s', " +
+                        "expect type %s but got %s", value, this.name,
+                        this.dataType.getSimpleName(),
+                        value.getClass().getSimpleName());
         if (this.checkFunc != null) {
             @SuppressWarnings("unchecked")
             T result = (T) value;
@@ -150,6 +162,15 @@ public class TypedOption<T, R> {
                             "Invalid option value for '%s': %s",
                             this.name, value);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected R convert(T value) {
+        return (R) value;
+    }
+
+    protected boolean forList() {
+        return false;
     }
 
     @Override

--- a/src/main/java/com/baidu/hugegraph/config/TypedOption.java
+++ b/src/main/java/com/baidu/hugegraph/config/TypedOption.java
@@ -150,17 +150,21 @@ public class TypedOption<T, R> {
 
     protected void check(Object value) {
         E.checkNotNull(value, "value", this.name);
-        E.checkArgument(this.dataType.isInstance(value),
-                        "Invalid type of value '%s' for option '%s', " +
-                        "expect type %s but got %s", value, this.name,
-                        this.dataType.getSimpleName(),
-                        value.getClass().getSimpleName());
+        if (!this.dataType.isInstance(value)) {
+            throw new ConfigException(
+                      "Invalid type of value '%s' for option '%s', " +
+                      "expect type %s but got %s", value, this.name,
+                      this.dataType.getSimpleName(),
+                      value.getClass().getSimpleName());
+        }
+
         if (this.checkFunc != null) {
             @SuppressWarnings("unchecked")
             T result = (T) value;
-            E.checkArgument(this.checkFunc.apply(result),
-                            "Invalid option value for '%s': %s",
-                            this.name, value);
+            if (!this.checkFunc.apply(result)) {
+                throw new ConfigException("Invalid option value for '%s': %s",
+                                          this.name, value);
+            }
         }
     }
 

--- a/src/main/java/com/baidu/hugegraph/version/CommonVersion.java
+++ b/src/main/java/com/baidu/hugegraph/version/CommonVersion.java
@@ -27,5 +27,5 @@ public class CommonVersion {
 
     // The second parameter of Version.of() is for all-in-one JAR
     public static final Version VERSION = Version.of(CommonVersion.class,
-                                                     "1.6.16");
+                                                     "1.7.0");
 }

--- a/src/test/java/com/baidu/hugegraph/unit/UnitTestSuite.java
+++ b/src/test/java/com/baidu/hugegraph/unit/UnitTestSuite.java
@@ -24,9 +24,10 @@ import org.junit.runners.Suite;
 
 import com.baidu.hugegraph.testutil.AssertTest;
 import com.baidu.hugegraph.testutil.WhiteboxTest;
-import com.baidu.hugegraph.unit.concurrent.RowLockTest;
 import com.baidu.hugegraph.unit.concurrent.LockGroupTest;
+import com.baidu.hugegraph.unit.concurrent.RowLockTest;
 import com.baidu.hugegraph.unit.config.HugeConfigTest;
+import com.baidu.hugegraph.unit.config.OptionSpaceTest;
 import com.baidu.hugegraph.unit.date.SafeDateFormatTest;
 import com.baidu.hugegraph.unit.event.EventHubTest;
 import com.baidu.hugegraph.unit.iterator.ExtendableIteratorTest;
@@ -60,6 +61,7 @@ import com.baidu.hugegraph.unit.version.VersionTest;
     LockGroupTest.class,
     RowLockTest.class,
     HugeConfigTest.class,
+    OptionSpaceTest.class,
     SafeDateFormatTest.class,
     EventHubTest.class,
     PerfUtilTest.class,

--- a/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
@@ -28,6 +28,7 @@ import static com.baidu.hugegraph.config.OptionChecker.rangeDouble;
 import static com.baidu.hugegraph.config.OptionChecker.rangeInt;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -35,6 +36,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.baidu.hugegraph.config.ConfigConvOption;
+import com.baidu.hugegraph.config.ConfigException;
 import com.baidu.hugegraph.config.ConfigListConvOption;
 import com.baidu.hugegraph.config.ConfigListOption;
 import com.baidu.hugegraph.config.ConfigOption;
@@ -44,16 +46,49 @@ import com.baidu.hugegraph.config.OptionSpace;
 import com.baidu.hugegraph.testutil.Assert;
 import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.unit.BaseUnitTest;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 public class HugeConfigTest extends BaseUnitTest {
 
-    private static final String CONF =
-            "src/test/java/com/baidu/hugegraph/unit/config/test.conf";
+    private static final String PATH =
+                         "src/test/java/com/baidu/hugegraph/unit/config/";
+    private static final String CONF = PATH + "test.conf";
 
     @BeforeClass
     public static void init() {
         OptionSpace.register("test", TestOptions.class.getName());
+    }
+
+    @Test
+    public void testOptionDataType() {
+        Assert.assertEquals(String.class, TestOptions.text1.dataType());
+        Assert.assertEquals(Integer.class, TestOptions.int1.dataType());
+        Assert.assertEquals(Long.class, TestOptions.long1.dataType());
+        Assert.assertEquals(Float.class, TestOptions.float1.dataType());
+        Assert.assertEquals(Double.class, TestOptions.double1.dataType());
+        Assert.assertEquals(Boolean.class, TestOptions.bool.dataType());
+
+        Assert.assertEquals(List.class, TestOptions.list.dataType());
+        Assert.assertEquals(List.class, TestOptions.map.dataType());
+
+        Assert.assertEquals(String.class, TestOptions.weekday.dataType());
+        Assert.assertEquals(List.class, TestOptions.weekdays.dataType());
+    }
+
+    @Test
+    public void testOptionDesc() {
+        Assert.assertEquals("description of group1.text1",
+                            TestOptions.text1.desc());
+        Assert.assertEquals("description of group1.text2 sub",
+                            TestSubOptions.text2.desc());
+    }
+
+    @Test
+    public void testOptionRequired() {
+        Assert.assertEquals(false, TestOptions.text1.required());
+        Assert.assertEquals(true, TestSubOptions.text2.required());
     }
 
     @Test
@@ -81,6 +116,92 @@ public class HugeConfigTest extends BaseUnitTest {
                             TestSubOptions.text2.toString());
         Assert.assertEquals("[String]group1.textsub=textsub-value",
                             TestSubOptions.textsub.toString());
+    }
+
+    @Test
+    public void testOptionWithError() {
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.text",
+                    "description of group1.text",
+                    disallowEmpty(),
+                    ""
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.choice",
+                    "description of group1.choice",
+                    allowValues("CHOICE-1", "CHOICE-2", "CHOICE-3"),
+                    "CHOICE-4"
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigListOption<>(
+                    "group1.list",
+                    true,
+                    "description of group1.list",
+                    disallowEmpty(),
+                    String.class,
+                    ImmutableList.of()
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.int",
+                    "description of group1.int",
+                    positiveInt(),
+                    0
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.int",
+                    "description of group1.int",
+                    nonNegativeInt(),
+                    -1
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.long",
+                    "description of group1.long",
+                    rangeInt(1L, 100L),
+                    0L
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.long",
+                    "description of group1.long",
+                    rangeInt(1L, 100L),
+                    101L
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.double",
+                    "description of group1.double",
+                    rangeDouble(1D, 10D),
+                    0D
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigOption<>(
+                    "group1.double",
+                    "description of group1.double",
+                    rangeDouble(1D, 10D),
+                    11D
+            );
+        });
     }
 
     @Test
@@ -114,6 +235,10 @@ public class HugeConfigTest extends BaseUnitTest {
         Assert.assertEquals(WeekDay.WEDNESDAY, config.get(TestOptions.weekday));
         Assert.assertEquals(Arrays.asList(WeekDay.SATURDAY, WeekDay.SUNDAY),
                             config.get(TestOptions.weekdays));
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new HugeConfig((Configuration) null);
+        });
     }
 
     @Test
@@ -170,6 +295,36 @@ public class HugeConfigTest extends BaseUnitTest {
                             config.get(TestSubOptions.textsub));
     }
 
+    @Test
+    public void testHugeConfigWithTypeError() {
+        OptionSpace.register("test-type-error",
+                             TestOptionsWithTypeError.class.getName());
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new HugeConfig(PATH + "test-type-error.conf");
+        });
+    }
+
+    @Test
+    public void testHugeConfigWithCheckError() throws Exception {
+        OptionSpace.register("test-check-error",
+                             TestOptionsWithCheckError.class.getName());
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new HugeConfig(PATH + "test-check-error.conf");
+        });
+    }
+
+    @Test
+    public void testHugeConfigWithListOptionError() throws Exception {
+        OptionSpace.register("test-list-error",
+                             TestOptionsWithListError.class.getName());
+
+        Assert.assertThrows(IllegalStateException.class, () -> {
+            new HugeConfig(PATH + "test-list-error.conf");
+        });
+    }
+
     public static class TestOptions extends OptionHolder {
 
         private static volatile TestOptions instance;
@@ -194,7 +349,6 @@ public class HugeConfigTest extends BaseUnitTest {
                 new ConfigOption<>(
                         "group1.text2",
                         "description of group1.text2",
-                        disallowEmpty(),
                         "text2-value"
                 );
 
@@ -304,8 +458,10 @@ public class HugeConfigTest extends BaseUnitTest {
         public static final ConfigOption<String> text2 =
                 new ConfigOption<>(
                         "group1.text2",
-                        "description of group1.text2",
+                        true,
+                        "description of group1.text2 sub",
                         disallowEmpty(),
+                        String.class,
                         "text2-value-override"
                 );
 
@@ -317,6 +473,87 @@ public class HugeConfigTest extends BaseUnitTest {
                         "textsub-value"
                 );
     }
+
+    public static class TestOptionsWithTypeError extends OptionHolder {
+
+        private static volatile TestOptionsWithTypeError instance;
+
+        public static synchronized TestOptionsWithTypeError instance() {
+            if (instance == null) {
+                instance = new TestOptionsWithTypeError();
+                instance.registerOptions();
+            }
+            return instance;
+        }
+
+        public static final ConfigOption<Integer> intError =
+                new ConfigOption<>(
+                        "group1.int_type_error",
+                        "description of group1.int_type_error",
+                        rangeInt(1, 100),
+                        1
+                );
+    }
+
+    public static class TestOptionsWithCheckError extends OptionHolder {
+
+        private static volatile TestOptionsWithCheckError instance;
+
+        public static synchronized TestOptionsWithCheckError instance() {
+            if (instance == null) {
+                instance = new TestOptionsWithCheckError();
+                instance.registerOptions();
+            }
+            return instance;
+        }
+
+        public static final ConfigOption<Integer> intError =
+                new ConfigOption<>(
+                        "group1.int_check_error",
+                        "description of group1.int_check_error",
+                        rangeInt(1, 100),
+                        1
+                );
+    }
+
+    public static class TestOptionsWithListError extends OptionHolder {
+
+        private static volatile TestOptionsWithListError instance;
+
+        public static synchronized TestOptionsWithListError instance() {
+            if (instance == null) {
+                instance = new TestOptionsWithListError();
+                instance.registerOptions();
+            }
+            return instance;
+        }
+
+        public static final InvalidConfigListOption<Integer> listError =
+                new InvalidConfigListOption<>(
+                        "group1.list_for_list_error",
+                        "description of group1.list_for_list_error",
+                        disallowEmpty(),
+                        1
+                );
+
+        static class InvalidConfigListOption<T> extends ConfigOption<List<T>> {
+
+            @SuppressWarnings("unchecked")
+            public InvalidConfigListOption(String name, String desc,
+                                           Predicate<List<T>> pred,
+                                           T... values) {
+                super(name, false, desc, pred,
+                      (Class<List<T>>) Arrays.asList(values).getClass(),
+                      Arrays.asList(values));
+            }
+
+            @Override
+            protected boolean forList() {
+                return false;
+            }
+        }
+    }
+
 
     public enum WeekDay {
 

--- a/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
@@ -202,6 +202,40 @@ public class HugeConfigTest extends BaseUnitTest {
                     11D
             );
         });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigListOption<>(
+                    "group1.list",
+                    "description of list with invalid default values",
+                    disallowEmpty()
+            );
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            new ConfigListOption<>(
+                    "group1.list",
+                    "description of list with invalid default values",
+                    null
+            );
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            new ConfigListConvOption<String, WeekDay>(
+                    "group1.list_conv",
+                    "description of list_conv with invalid default values",
+                    disallowEmpty(),
+                    s -> WeekDay.valueOf(s)
+            );
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            new ConfigListConvOption<String, WeekDay>(
+                    "group1.list_conv",
+                    "description of list_conv with invalid default values",
+                    null,
+                    s -> WeekDay.valueOf(s)
+            );
+        });
     }
 
     @Test

--- a/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
@@ -105,15 +105,15 @@ public class HugeConfigTest extends BaseUnitTest {
 
         Assert.assertEquals(true, config.get(TestOptions.bool));
 
-        Assert.assertEquals(WeekDay.WEDNESDAY, config.get(TestOptions.weekday));
-        Assert.assertEquals(Arrays.asList(WeekDay.SATURDAY, WeekDay.SUNDAY),
-                            config.get(TestOptions.weekdays));
-
         Assert.assertEquals(Arrays.asList("list-value1", "list-value2"),
                             config.get(TestOptions.list));
 
         Assert.assertEquals(ImmutableMap.of("key1", "value1", "key2", "value2"),
                             config.getMap(TestOptions.map));
+
+        Assert.assertEquals(WeekDay.WEDNESDAY, config.get(TestOptions.weekday));
+        Assert.assertEquals(Arrays.asList(WeekDay.SATURDAY, WeekDay.SUNDAY),
+                            config.get(TestOptions.weekdays));
     }
 
     @Test
@@ -140,6 +140,10 @@ public class HugeConfigTest extends BaseUnitTest {
 
         Assert.assertEquals(ImmutableMap.of("key1", "value1", "key3", "value3"),
                             config.getMap(TestOptions.map));
+
+        Assert.assertEquals(WeekDay.SUNDAY, config.get(TestOptions.weekday));
+        Assert.assertEquals(Arrays.asList(WeekDay.SATURDAY, WeekDay.FRIDAY),
+                            config.get(TestOptions.weekdays));
     }
 
     @Test
@@ -258,7 +262,7 @@ public class HugeConfigTest extends BaseUnitTest {
                         true
                 );
 
-        public static final ConfigConvOption<WeekDay> weekday =
+        public static final ConfigConvOption<String, WeekDay> weekday =
                 new ConfigConvOption<>(
                         "group1.weekday",
                         "description of group1.weekday",
@@ -275,7 +279,6 @@ public class HugeConfigTest extends BaseUnitTest {
                         inValues("SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY",
                                  "THURSDAY", "FRIDAY", "SATURDAY"),
                         WeekDay::valueOf,
-                        String.class,
                         "SATURDAY", "SUNDAY"
                 );
 
@@ -284,7 +287,6 @@ public class HugeConfigTest extends BaseUnitTest {
                         "group1.list",
                         "description of group1.list",
                         disallowEmpty(),
-                        String.class,
                         "list-value1", "list-value2"
                 );
 
@@ -293,7 +295,6 @@ public class HugeConfigTest extends BaseUnitTest {
                         "group1.map",
                         "description of group1.map",
                         disallowEmpty(),
-                        String.class,
                         "key1:value1", "key2:value2"
                 );
     }

--- a/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/config/HugeConfigTest.java
@@ -588,7 +588,6 @@ public class HugeConfigTest extends BaseUnitTest {
         }
     }
 
-
     public enum WeekDay {
 
         SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY;

--- a/src/test/java/com/baidu/hugegraph/unit/config/OptionSpaceTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/config/OptionSpaceTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.unit.config;
+
+import static com.baidu.hugegraph.config.OptionChecker.disallowEmpty;
+
+import org.junit.Test;
+
+import com.baidu.hugegraph.config.ConfigException;
+import com.baidu.hugegraph.config.ConfigOption;
+import com.baidu.hugegraph.config.OptionHolder;
+import com.baidu.hugegraph.config.OptionSpace;
+import com.baidu.hugegraph.testutil.Assert;
+import com.baidu.hugegraph.unit.BaseUnitTest;
+import com.google.common.base.Predicate;
+
+public class OptionSpaceTest extends BaseUnitTest {
+
+    @Test
+    public void tesRegister() {
+        int oldSize = OptionSpace.keys().size();
+
+        OptionSpace.register("testgroup1", OptionHolder1.class.getName());
+        Assert.assertEquals(oldSize + 2, OptionSpace.keys().size());
+        Assert.assertTrue(OptionSpace.containKey("group1.text1"));
+        Assert.assertTrue(OptionSpace.containKey("group1.text2"));
+
+        OptionSpace.register("testgroup1", new OptionHolder1());
+        Assert.assertEquals(oldSize + 2, OptionSpace.keys().size());
+        Assert.assertTrue(OptionSpace.containKey("group1.text1"));
+        Assert.assertTrue(OptionSpace.containKey("group1.text2"));
+
+        OptionSpace.register("testgroup2", OptionHolder2.class.getName());
+        Assert.assertEquals(oldSize + 4, OptionSpace.keys().size());
+
+        Assert.assertTrue(OptionSpace.containKey("testgroup1.text1"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup1.text2"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup2.text1"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup2.text2"));
+
+        Assert.assertEquals("text1 value",
+                            OptionSpace.get("testgroup1.text1").defaultValue());
+        Assert.assertEquals("text2 value",
+                            OptionSpace.get("testgroup1.text2").defaultValue());
+        Assert.assertEquals("text1 value",
+                            OptionSpace.get("testgroup2.text1").defaultValue());
+        Assert.assertEquals("text2 value",
+                            OptionSpace.get("testgroup2.text2").defaultValue());
+    }
+
+    @Test
+    public void testRegisterWithError() {
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error", "fake");
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error", Exception.class.getName());
+        });
+
+        class OptionHolderWithoutInstance extends OptionHolder {
+            // no instance()
+        }
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error",
+                                 OptionHolderWithoutInstance.class.getName());
+        });
+
+        class OptionHolderWithNonStaticInstance extends OptionHolder {
+
+            // not static instance()
+            @SuppressWarnings("unused")
+            public OptionHolderWithNonStaticInstance instance() {
+                return new OptionHolderWithNonStaticInstance();
+            }
+        }
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error", OptionHolderWithNonStaticInstance
+                                               .class.getName());
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error",
+                                 OptionHolderWithInstanceNull.class.getName());
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error",
+                                 OptionHolderWithInstanceThrow.class.getName());
+        });
+
+        Assert.assertThrows(ConfigException.class, () -> {
+            OptionSpace.register("test-error",
+                                 OptionHolderWithInvalidOption.class.getName());
+        });
+    }
+
+    public static class OptionHolderWithInstanceNull extends OptionHolder {
+
+        public static OptionHolderWithInstanceNull instance() {
+            return null;
+        }
+    }
+
+    public static class OptionHolderWithInstanceThrow extends OptionHolder {
+
+        public static OptionHolderWithInstanceNull instance() {
+            throw new RuntimeException("test error");
+        }
+    }
+
+    public static class OptionHolderWithInvalidOption extends OptionHolder {
+
+        public static OptionHolderWithInvalidOption instance() {
+            return new OptionHolderWithInvalidOption();
+        }
+
+        OptionHolderWithInvalidOption() {
+            this.registerOptions();
+        }
+
+        public static final String fake = "fake";
+
+        public static final ConfigOption<String> invalid =
+                new InvalidOption<>(
+                        "group1.text1",
+                        "description of group1.text1",
+                        disallowEmpty(),
+                        "value"
+                );
+
+        public static class InvalidOption<T> extends ConfigOption<T> {
+
+            public InvalidOption(String name, String desc,
+                                 Predicate<T> pred, T value) {
+                super(name, desc, pred, value);
+            }
+
+            @Override
+            public String name() {
+                throw new RuntimeException("fake");
+            }
+        }
+    }
+
+    public static class OptionHolder1 extends OptionHolder {
+
+        public static OptionHolder1 instance() {
+            return new OptionHolder1();
+        }
+
+        OptionHolder1() {
+            this.registerOptions();
+        }
+
+        public static final ConfigOption<String> text1 =
+                new ConfigOption<>(
+                        "testgroup1.text1",
+                        "description of testgroup1.text1",
+                        disallowEmpty(),
+                        "text1 value"
+                );
+
+        public static final ConfigOption<String> text2 =
+                new ConfigOption<>(
+                        "testgroup1.text2",
+                        "description of testgroup1.text2",
+                        disallowEmpty(),
+                        "text2 value"
+                );
+    }
+
+    public static class OptionHolder2 extends OptionHolder {
+
+        public static OptionHolder2 instance() {
+            return new OptionHolder2();
+        }
+
+        OptionHolder2() {
+            this.registerOptions();
+        }
+
+        public static final ConfigOption<String> text1 =
+                new ConfigOption<>(
+                        "testgroup2.text1",
+                        "description of testgroup2.text1",
+                        disallowEmpty(),
+                        "text1 value"
+                );
+
+        public static final ConfigOption<String> text2 =
+                new ConfigOption<>(
+                        "testgroup2.text2",
+                        "description of testgroup2.text2",
+                        disallowEmpty(),
+                        "text2 value"
+                );
+    }
+}

--- a/src/test/java/com/baidu/hugegraph/unit/config/OptionSpaceTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/config/OptionSpaceTest.java
@@ -39,13 +39,13 @@ public class OptionSpaceTest extends BaseUnitTest {
 
         OptionSpace.register("testgroup1", OptionHolder1.class.getName());
         Assert.assertEquals(oldSize + 2, OptionSpace.keys().size());
-        Assert.assertTrue(OptionSpace.containKey("group1.text1"));
-        Assert.assertTrue(OptionSpace.containKey("group1.text2"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup1.text1"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup1.text2"));
 
         OptionSpace.register("testgroup1", new OptionHolder1());
         Assert.assertEquals(oldSize + 2, OptionSpace.keys().size());
-        Assert.assertTrue(OptionSpace.containKey("group1.text1"));
-        Assert.assertTrue(OptionSpace.containKey("group1.text2"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup1.text1"));
+        Assert.assertTrue(OptionSpace.containKey("testgroup1.text2"));
 
         OptionSpace.register("testgroup2", OptionHolder2.class.getName());
         Assert.assertEquals(oldSize + 4, OptionSpace.keys().size());
@@ -75,22 +75,11 @@ public class OptionSpaceTest extends BaseUnitTest {
             OptionSpace.register("test-error", Exception.class.getName());
         });
 
-        class OptionHolderWithoutInstance extends OptionHolder {
-            // no instance()
-        }
         Assert.assertThrows(ConfigException.class, () -> {
             OptionSpace.register("test-error",
                                  OptionHolderWithoutInstance.class.getName());
         });
 
-        class OptionHolderWithNonStaticInstance extends OptionHolder {
-
-            // not static instance()
-            @SuppressWarnings("unused")
-            public OptionHolderWithNonStaticInstance instance() {
-                return new OptionHolderWithNonStaticInstance();
-            }
-        }
         Assert.assertThrows(ConfigException.class, () -> {
             OptionSpace.register("test-error", OptionHolderWithNonStaticInstance
                                                .class.getName());
@@ -110,6 +99,18 @@ public class OptionSpaceTest extends BaseUnitTest {
             OptionSpace.register("test-error",
                                  OptionHolderWithInvalidOption.class.getName());
         });
+    }
+
+    public static class OptionHolderWithoutInstance extends OptionHolder {
+        // no instance()
+    }
+
+    public static class OptionHolderWithNonStaticInstance extends OptionHolder {
+
+        // not static instance()
+        public OptionHolderWithNonStaticInstance instance() {
+            return new OptionHolderWithNonStaticInstance();
+        }
     }
 
     public static class OptionHolderWithInstanceNull extends OptionHolder {
@@ -132,7 +133,7 @@ public class OptionSpaceTest extends BaseUnitTest {
             return new OptionHolderWithInvalidOption();
         }
 
-        OptionHolderWithInvalidOption() {
+        private OptionHolderWithInvalidOption() {
             this.registerOptions();
         }
 

--- a/src/test/java/com/baidu/hugegraph/unit/config/test-check-error.conf
+++ b/src/test/java/com/baidu/hugegraph/unit/config/test-check-error.conf
@@ -1,0 +1,1 @@
+group1.int_check_error=101

--- a/src/test/java/com/baidu/hugegraph/unit/config/test-list-error.conf
+++ b/src/test/java/com/baidu/hugegraph/unit/config/test-list-error.conf
@@ -1,0 +1,1 @@
+group1.list_for_list_error=[1,2,3]

--- a/src/test/java/com/baidu/hugegraph/unit/config/test-list-error.conf
+++ b/src/test/java/com/baidu/hugegraph/unit/config/test-list-error.conf
@@ -1,1 +1,2 @@
 group1.list_for_list_error=[1,2,3]
+

--- a/src/test/java/com/baidu/hugegraph/unit/config/test-type-error.conf
+++ b/src/test/java/com/baidu/hugegraph/unit/config/test-type-error.conf
@@ -1,0 +1,1 @@
+group1.int_type_error=string

--- a/src/test/java/com/baidu/hugegraph/unit/config/test.conf
+++ b/src/test/java/com/baidu/hugegraph/unit/config/test.conf
@@ -14,3 +14,6 @@ group1.bool=false
 
 group1.list=[file-v1, file-v2, file-v3]
 group1.map=[key1:value1, key3:value3]
+
+group1.weekday=SUNDAY
+group1.weekdays=[SATURDAY, FRIDAY]

--- a/src/test/java/com/baidu/hugegraph/unit/config/test.conf
+++ b/src/test/java/com/baidu/hugegraph/unit/config/test.conf
@@ -17,3 +17,5 @@ group1.map=[key1:value1, key3:value3]
 
 group1.weekday=SUNDAY
 group1.weekdays=[SATURDAY, FRIDAY]
+
+group1.no-used=value


### PR DESCRIPTION
also fix ConfigConvOption/ConfigListConvOption read bug

fix: github.com/hugegraph/hugegraph/issues/774
Change-Id: I716c9f187128be9b0d173f152da05e5bdc2208a3